### PR TITLE
wip use sqlalchemy & migrate during site build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ flask_mail
 GitPython
 requests>=2.20.0
 pyyaml
+flask_sqlalchemy
+flask_migrate


### PR DESCRIPTION
ref https://github.com/Subscribie/subscribie/issues/141

This impacts how sites are built. 

This PR introduces:

flask_sqlalchemy
flask_migrate


During a site build, flask_migrate `upgrade` is called to migrate the initial database. 

This PR removes the call to `subscribie migrate` in favour of using flask_migrate tools/api. 
